### PR TITLE
Change category 14 to a news flash

### DIFF
--- a/lib/alerts.js
+++ b/lib/alerts.js
@@ -326,7 +326,7 @@ function getAlertTypeByHistoricalCategory(category) {
         case 13:
             return 'earlyWarning';
         case 14:
-            return 'earlyWarning';
+            return 'newsFlash';
         case 15:
             return 'missilesDrill';
         case 16:


### PR DESCRIPTION
According to the data from the api, category 14 is a news flash.

```json
{
    "data": "ברחבי הארץ",
    "date": "14.06.2025",
    "time": "23:04:04",
    "alertDate": "2025-06-14T23:04:00",
    "category": 14,
    "category_desc": "מבזק",
    "matrix_id": 10,
    "rid": 78733
}
```